### PR TITLE
run onnx in guest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,8 +2509,11 @@ dependencies = [
 name = "onnx-guest"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "getrandom 0.2.15",
  "jolt-sdk",
  "onnx-util",
+ "tract-onnx",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,6 +2501,7 @@ dependencies = [
  "ndarray",
  "onnx-guest",
  "onnx-util",
+ "ort",
  "rand 0.8.5",
  "tract-onnx",
 ]
@@ -2581,6 +2582,31 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
+dependencies = [
+ "half",
+ "ndarray",
+ "ort-sys",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
+dependencies = [
+ "flate2",
+ "pkg-config",
+ "sha2",
+ "tar",
+ "ureq",
+]
 
 [[package]]
 name = "overflow"
@@ -3346,7 +3372,9 @@ version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3705,6 +3733,17 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4495,6 +4534,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "socks",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4669,6 +4724,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/examples/onnx/Cargo.toml
+++ b/examples/onnx/Cargo.toml
@@ -23,3 +23,7 @@ path = "./src/parse.rs"
 [[bin]]
 name = "inference"
 path = "./src/inference.rs"
+
+[[bin]]
+name = "prove_onnx"
+path = "./src/prove_onnx.rs"

--- a/examples/onnx/Cargo.toml
+++ b/examples/onnx/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.75"
 onnx-util = { package = "onnx-util", path = "./util" }
 rand = "0.8.5"
 clap = "4.5.35"
+ort = "2.0.0-rc.9"
 
 [features]
 icicle = ["jolt-sdk/icicle"]
@@ -27,3 +28,7 @@ path = "./src/inference.rs"
 [[bin]]
 name = "prove_onnx"
 path = "./src/prove_onnx.rs"
+
+[[bin]]
+name = "ort"
+path = "./src/ort.rs"

--- a/examples/onnx/guest/Cargo.toml
+++ b/examples/onnx/guest/Cargo.toml
@@ -9,3 +9,6 @@ guest = []
 [dependencies]
 jolt = { package = "jolt-sdk", path = "../../../jolt-sdk", features = ["guest-std"] }
 onnx-util = { package = "onnx-util", path = "../util", default-features = false, features = ["guest"] }
+tract-onnx = "0.21.1"
+anyhow = "1.0.75"
+getrandom = { version = "0.2", features = ["custom"] }

--- a/examples/onnx/src/ort.rs
+++ b/examples/onnx/src/ort.rs
@@ -1,0 +1,21 @@
+use ndarray::Array;
+use ort::{
+    inputs,
+    session::{builder::GraphOptimizationLevel, Session},
+};
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let session = Session::builder()?
+        .with_optimization_level(GraphOptimizationLevel::Level1)?
+        .with_intra_threads(1)?
+        .commit_from_file("examples/onnx/data/linear.onnx")?;
+
+    let input: Array<f32, _> = Array::from_shape_vec((1, 1), vec![0.3f32])?;
+    // ndarray を ONNX Runtime が要求する Tensor に変換
+    let outputs = session.run(inputs![input]?)?;
+    let output = &outputs[0].try_extract_tensor::<f32>()?;
+    println!("Output: {:?}", output.as_slice().unwrap()[0]);
+
+    Ok(())
+}

--- a/examples/onnx/src/prove_onnx.rs
+++ b/examples/onnx/src/prove_onnx.rs
@@ -1,0 +1,10 @@
+pub fn main() {
+    let test_value = 0.4f32;
+    let model_path = "examples/onnx/data/linear.onnx";
+
+    let (prove_onnx, verify_onnx) = guest::build_onnx();
+    let (output, proof) = prove_onnx(model_path, test_value);
+    let is_valid = verify_onnx(proof);
+    assert!(is_valid, "Invalid output for ONNX implementation");
+    println!("Output: {}", output);
+}


### PR DESCRIPTION
Command:

```bash
cargo run -r -p onnx --bin prove_onnx
```

To run on local by using ort library:

```
cargo run -r -p onnx --bin ort
```

(I tried to run Jolt guest with other libraries besides tract_onnx, such as ort, but all of them use the onnx runtime, which is impossible because that runtime does not provide the binaries for target riscv32im-jolt-zkvm-elf. )