### PR TITLE
fixed MeanOfSquares - issue with dimension when expanding

### DIFF
--- a/onnx-tracer/src/graph/utilities.rs
+++ b/onnx-tracer/src/graph/utilities.rs
@@ -538,6 +538,18 @@ pub fn new_op_from_onnx(
 
             SupportedOp::Linear(PolyOp::Sum { axes })
         }
+        "Reduce<MeanOfSquares>" => {
+            if inputs.len() != 1 {
+                return Err(Box::new(GraphError::InvalidDims(
+                    idx,
+                    "mean of squares".to_string(),
+                )));
+            };
+            let op = load_op::<Reduce>(node.op(), idx, node.op().name().to_string())?;
+            let axes = op.axes.into_iter().collect();
+
+            SupportedOp::Linear(PolyOp::MeanOfSquares { axes })
+        }
         "Max" => {
             // Extract the max value
             // first find the input that is a constant

--- a/onnx-tracer/src/tensor/ops.rs
+++ b/onnx-tracer/src/tensor/ops.rs
@@ -3874,6 +3874,32 @@ pub mod nonlinearities {
         let sum = sum(a).unwrap();
         const_div(&sum, (scale * a.len()) as f64)
     }
+
+    /// Mean of squares axes
+    /// # Arguments
+    /// * `a` - Tensor
+    /// * `axis` - [usize]
+    /// # Examples
+    /// ```
+    /// use ezkl::tensor::Tensor;
+    /// use ezkl::tensor::ops::nonlinearities::mean_of_squares_axes;
+    /// let x = Tensor::<i128>::new(
+    /// Some(&[2, 15, 2, 1, 1, 0]),
+    /// &[2, 3],
+    /// ).unwrap();
+    /// let result = mean_of_squares_axes(&x, &[1]);
+    /// let expected = Tensor::<i128>::new(
+    /// Some(&[78, 1]),
+    /// &[2, 1],
+    /// ).unwrap();
+    /// assert_eq!(result, expected);
+    /// ```
+    pub fn mean_of_squares_axes(a: &Tensor<i128>, axes: &[usize]) -> Tensor<i128> {
+        let square = a.map(|a_i| a_i * a_i);
+        let sum = sum_axes(&square, axes).unwrap();
+        let denominator = a.len() / sum.len();
+        const_div(&sum, denominator as f64)
+    }
 }
 
 /// Ops that return the transcript i.e intermediate calcs of an op

--- a/onnx-tracer/src/trace_types.rs
+++ b/onnx-tracer/src/trace_types.rs
@@ -92,6 +92,7 @@ pub enum ONNXOpcode {
     /// Used for the ReduceMean operator, which is internally converted to a
     /// combination of Sum and Div operations.
     Sum,
+    MeanOfSquares,
     Sigmoid,
     Softmax,
 }


### PR DESCRIPTION
The log does not show the unrecognized operator as in issue #38 
However now an error rises concerning tensor dimensions when expanding.