### PR TITLE
fix: added WORD_SIZE const generic to "prove" function.

### DIFF
--- a/zkml-jolt-core/src/jolt/lookup_trace.rs
+++ b/zkml-jolt-core/src/jolt/lookup_trace.rs
@@ -7,17 +7,9 @@ use jolt_core::jolt::{
 };
 
 // pub const WORD_SIZE: usize = 32;
-
-macro_rules! test_const_generic {
-    ( $variant:ident : $inner:ident <WORD_SIZE>) => {};
-}
-
-test_const_generic!(Add: ADD<WORD_SIZE>);
-
 macro_rules! define_lookup_enum {
     (
         enum $enum_name:ident,
-     //   const $word_size:ident,
         trait $trait_name:ident,
         $($variant:ident : $inner:ident < WORD_SIZE >),+ $(,)?
     ) => {

--- a/zkml-jolt-core/src/jolt/lookup_trace.rs
+++ b/zkml-jolt-core/src/jolt/lookup_trace.rs
@@ -6,23 +6,29 @@ use jolt_core::jolt::{
     lookup_table::LookupTables,
 };
 
-pub const WORD_SIZE: usize = 32;
+// pub const WORD_SIZE: usize = 32;
+
+macro_rules! test_const_generic {
+    ( $variant:ident : $inner:ident <WORD_SIZE>) => {};
+}
+
+test_const_generic!(Add: ADD<WORD_SIZE>);
 
 macro_rules! define_lookup_enum {
     (
         enum $enum_name:ident,
-        const $word_size:ident,
+     //   const $word_size:ident,
         trait $trait_name:ident,
-        $($variant:ident : $inner:ty),+ $(,)?
+        $($variant:ident : $inner:ident < WORD_SIZE >),+ $(,)?
     ) => {
         #[derive(Debug)]
-        pub enum $enum_name {
+        pub enum $enum_name<const WORD_SIZE: usize> {
             $(
-                $variant($inner),
+                $variant($inner<WORD_SIZE>),
             )+
         }
 
-        impl $trait_name<$word_size> for $enum_name {
+        impl<const WORD_SIZE: usize> $trait_name<WORD_SIZE> for $enum_name<WORD_SIZE> {
             fn to_instruction_inputs(&self) -> (u64, i64) {
                 match self {
                     $(
@@ -60,14 +66,13 @@ macro_rules! define_lookup_enum {
 
 define_lookup_enum!(
     enum ONNXLookup,
-    const WORD_SIZE,
     trait LookupQuery,
     Add: ADD<WORD_SIZE>,
     Sub: SUB<WORD_SIZE>,
     Mul: MUL<WORD_SIZE>,
 );
 
-impl InstructionLookup<WORD_SIZE> for ONNXLookup {
+impl<const WORD_SIZE: usize> InstructionLookup<WORD_SIZE> for ONNXLookup<WORD_SIZE> {
     fn lookup_table(&self) -> Option<LookupTables<WORD_SIZE>> {
         match self {
             ONNXLookup::Add(add) => add.lookup_table(),
@@ -77,12 +82,12 @@ impl InstructionLookup<WORD_SIZE> for ONNXLookup {
     }
 }
 
-pub trait LookupTrace {
-    fn to_lookup(&self) -> Option<ONNXLookup>;
+pub trait LookupTrace<const WORD_SIZE: usize> {
+    fn to_lookup(&self) -> Option<ONNXLookup<WORD_SIZE>>;
 }
 
-impl LookupTrace for ONNXCycle {
-    fn to_lookup(&self) -> Option<ONNXLookup> {
+impl<const WORD_SIZE: usize> LookupTrace<WORD_SIZE> for ONNXCycle {
+    fn to_lookup(&self) -> Option<ONNXLookup<WORD_SIZE>> {
         match self.instr.opcode {
             ONNXOpcode::Add => Some(ONNXLookup::Add(ADD(self.ts1_val(), self.ts2_val()))),
             ONNXOpcode::Sub => Some(ONNXLookup::Sub(SUB(self.ts1_val(), self.ts2_val()))),

--- a/zkml-jolt-core/src/subprotocols/sparse_dense_shout.rs
+++ b/zkml-jolt-core/src/subprotocols/sparse_dense_shout.rs
@@ -32,7 +32,7 @@ use rayon::prelude::*;
 use strum::{EnumCount, IntoEnumIterator};
 
 use crate::jolt::lookup_trace::LookupTrace;
-use crate::jolt::lookup_trace::WORD_SIZE;
+// use crate::jolt::lookup_trace::WORD_SIZE;
 
 /// Computes the bit-length of the suffix, for the current (`j`th) round
 /// of sumcheck.
@@ -164,7 +164,11 @@ fn prover_msg_read_checking<const WORD_SIZE: usize, F: JoltField>(
 }
 
 #[allow(clippy::type_complexity)]
-pub fn prove_sparse_dense_shout<F: JoltField, ProofTranscript: Transcript>(
+pub fn prove_sparse_dense_shout<
+    const WORD_SIZE: usize,
+    F: JoltField,
+    ProofTranscript: Transcript,
+>(
     trace: &[ONNXCycle],
     r_cycle: &[F],
     transcript: &mut ProofTranscript,


### PR DESCRIPTION
Adds const WORD_SIZE: usize generic to `prove_sparse_dense_shout`.
Other issues caused by `lookup_trace.rs`, which I don't know how to solve due to use of a macro to implement trait `LookupQuery`.