### PR TITLE
feat: ReLU lookup-table (MLE) logic 

### DIFF
--- a/jolt-core/src/jolt/lookup_table/mod.rs
+++ b/jolt-core/src/jolt/lookup_table/mod.rs
@@ -27,7 +27,7 @@ use virtual_sra::VirtualSRATable;
 use virtual_srl::VirtualSRLTable;
 use xor::XorTable;
 
-use crate::field::JoltField;
+use crate::{field::JoltField, jolt::lookup_table::relu::ReLUTable};
 use derive_more::From;
 use std::fmt::Debug;
 
@@ -66,6 +66,7 @@ pub mod not_equal;
 pub mod or;
 pub mod pow2;
 pub mod range_check;
+pub mod relu;
 pub mod shift_right_bitmask;
 pub mod signed_greater_than_equal;
 pub mod signed_less_than;
@@ -110,6 +111,7 @@ pub enum LookupTables<const WORD_SIZE: usize> {
     VirtualSRL(VirtualSRLTable<WORD_SIZE>),
     VirtualSRA(VirtualSRATable<WORD_SIZE>),
     VirtualROTRI(VirtualRotrTable<WORD_SIZE>),
+    ReLU(ReLUTable<WORD_SIZE>),
 }
 
 impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
@@ -144,6 +146,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.materialize(),
             LookupTables::VirtualSRA(table) => table.materialize(),
             LookupTables::VirtualROTRI(table) => table.materialize(),
+            LookupTables::ReLU(table) => table.materialize(),
         }
     }
 
@@ -171,6 +174,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.materialize_entry(index),
             LookupTables::VirtualSRA(table) => table.materialize_entry(index),
             LookupTables::VirtualROTRI(table) => table.materialize_entry(index),
+            LookupTables::ReLU(table) => table.materialize_entry(index),
         }
     }
 
@@ -198,6 +202,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.evaluate_mle(r),
             LookupTables::VirtualSRA(table) => table.evaluate_mle(r),
             LookupTables::VirtualROTRI(table) => table.evaluate_mle(r),
+            LookupTables::ReLU(table) => table.evaluate_mle(r),
         }
     }
 
@@ -225,6 +230,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.suffixes(),
             LookupTables::VirtualSRA(table) => table.suffixes(),
             LookupTables::VirtualROTRI(table) => table.suffixes(),
+            LookupTables::ReLU(table) => table.suffixes(),
         }
     }
 
@@ -256,6 +262,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.combine(prefixes, suffixes),
             LookupTables::VirtualSRA(table) => table.combine(prefixes, suffixes),
             LookupTables::VirtualROTRI(table) => table.combine(prefixes, suffixes),
+            LookupTables::ReLU(table) => table.combine(prefixes, suffixes),
         }
     }
 }

--- a/jolt-core/src/jolt/lookup_table/prefixes/lower_word_no_msb.rs
+++ b/jolt-core/src/jolt/lookup_table/prefixes/lower_word_no_msb.rs
@@ -1,0 +1,90 @@
+use crate::{
+    field::JoltField,
+    subprotocols::sparse_dense_shout::{current_suffix_len, LookupBits},
+};
+
+use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+
+pub enum LowerWordNoMsbPrefix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F>
+    for LowerWordNoMsbPrefix<WORD_SIZE>
+{
+    fn prefix_mle(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<F>,
+        c: u32,
+        mut b: LookupBits,
+        j: usize,
+    ) -> F {
+        // Ignore high-order variables
+        if j < WORD_SIZE {
+            return F::zero();
+        }
+
+        let two = 2 * WORD_SIZE;
+        let c_f = F::from_u8(c as u8);
+        let mut result = checkpoints[Prefixes::LowerWordNoMsb].unwrap_or(F::zero());
+
+        let mut add = |shift: usize, val: F| {
+            result += F::from_u64(1u64 << shift) * val;
+        };
+
+        match (r_x, j) {
+            // only y contributes here
+            (Some(_rx), jj) if jj == WORD_SIZE + 1 => {
+                let y_shift = two - j - 1;
+                add(y_shift, c_f);
+            }
+
+            // general case for r_x
+            (Some(rx), _) => {
+                let x_shift = two - j;
+                let y_shift = x_shift - 1;
+                add(x_shift, rx);
+                add(y_shift, c_f);
+            }
+
+            (None, jj) if jj == WORD_SIZE => {
+                // no-op
+            }
+
+            // general case: x=c and y=msb(b)
+            (None, _) => {
+                let y_msb = b.pop_msb();
+                let x_shift = two - j - 1;
+                let y_shift = x_shift - 1;
+                add(x_shift, c_f);
+                add(y_shift, F::from_u8(y_msb));
+            }
+        }
+
+        let suffix_len = current_suffix_len(two, j);
+        result += F::from_u64(u64::from(b) << suffix_len);
+
+        result
+    }
+
+    fn update_prefix_checkpoint(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: F,
+        r_y: F,
+        j: usize,
+    ) -> PrefixCheckpoint<F> {
+        if j < WORD_SIZE {
+            return None.into();
+        }
+        if j == WORD_SIZE + 1 {
+            let y_shift = 2 * WORD_SIZE - j - 1;
+            let updated = checkpoints[Prefixes::LowerWordNoMsb].unwrap_or(F::zero())
+                + F::from_u64(1 << y_shift) * r_y;
+            return Some(updated).into();
+        }
+        let x_shift = 2 * WORD_SIZE - j;
+        let y_shift = 2 * WORD_SIZE - j - 1;
+        let updated = checkpoints[Prefixes::LowerWordNoMsb].unwrap_or(F::zero())
+            + F::from_u64(1 << x_shift) * r_x
+            + F::from_u64(1 << y_shift) * r_y;
+        Some(updated).into()
+    }
+}

--- a/jolt-core/src/jolt/lookup_table/prefixes/mod.rs
+++ b/jolt-core/src/jolt/lookup_table/prefixes/mod.rs
@@ -1,5 +1,7 @@
 use crate::jolt::lookup_table::prefixes::left_shift::LeftShiftPrefix;
 use crate::jolt::lookup_table::prefixes::left_shift_helper::LeftShiftHelperPrefix;
+use crate::jolt::lookup_table::prefixes::lower_word_no_msb::LowerWordNoMsbPrefix;
+use crate::jolt::lookup_table::prefixes::msb::MsbPrefix;
 use crate::{field::JoltField, subprotocols::sparse_dense_shout::LookupBits};
 use lsb::LsbPrefix;
 use negative_divisor_equals_remainder::NegativeDivisorEqualsRemainderPrefix;
@@ -38,8 +40,10 @@ pub mod left_msb;
 pub mod left_shift;
 pub mod left_shift_helper;
 pub mod lower_word;
+pub mod lower_word_no_msb;
 pub mod lsb;
 pub mod lt;
+pub mod msb;
 pub mod negative_divisor_equals_remainder;
 pub mod negative_divisor_greater_than_remainder;
 pub mod negative_divisor_zero_remainder;
@@ -113,11 +117,13 @@ pub enum Prefixes {
     NegativeDivisorEqualsRemainder,
     NegativeDivisorGreaterThanRemainder,
     Lsb,
+    Msb,
     Pow2,
     RightShift,
     SignExtension,
     LeftShift,
     LeftShiftHelper,
+    LowerWordNoMsb,
 }
 
 #[derive(Clone, Copy)]
@@ -178,6 +184,9 @@ impl Prefixes {
             Prefixes::LowerWord => {
                 LowerWordPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j)
             }
+            Prefixes::LowerWordNoMsb => {
+                LowerWordNoMsbPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j)
+            }
             Prefixes::UpperWord => {
                 UpperWordPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j)
             }
@@ -211,6 +220,7 @@ impl Prefixes {
                 NegativeDivisorGreaterThanRemainderPrefix::prefix_mle(checkpoints, r_x, c, b, j)
             }
             Prefixes::Lsb => LsbPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
+            Prefixes::Msb => MsbPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
             Prefixes::Pow2 => Pow2Prefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
             Prefixes::RightShift => RightShiftPrefix::prefix_mle(checkpoints, r_x, c, b, j),
             Prefixes::SignExtension => {
@@ -269,6 +279,14 @@ impl Prefixes {
         match self {
             Prefixes::LowerWord => {
                 LowerWordPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
+            }
+            Prefixes::LowerWordNoMsb => {
+                LowerWordNoMsbPrefix::<WORD_SIZE>::update_prefix_checkpoint(
+                    checkpoints,
+                    r_x,
+                    r_y,
+                    j,
+                )
             }
             Prefixes::UpperWord => {
                 UpperWordPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
@@ -343,6 +361,9 @@ impl Prefixes {
             }
             Prefixes::Lsb => {
                 LsbPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
+            }
+            Prefixes::Msb => {
+                MsbPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
             }
             Prefixes::Pow2 => {
                 Pow2Prefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)

--- a/jolt-core/src/jolt/lookup_table/prefixes/msb.rs
+++ b/jolt-core/src/jolt/lookup_table/prefixes/msb.rs
@@ -1,0 +1,39 @@
+use crate::{
+    field::JoltField, jolt::lookup_table::prefixes::Prefixes,
+    subprotocols::sparse_dense_shout::LookupBits,
+};
+
+use super::{PrefixCheckpoint, SparseDensePrefix};
+
+pub enum MsbPrefix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for MsbPrefix<WORD_SIZE> {
+    fn prefix_mle(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<F>,
+        c: u32,
+        _: LookupBits,
+        j: usize,
+    ) -> F {
+        match j {
+            j if j == WORD_SIZE => F::from_u32(c),
+            j if j == WORD_SIZE + 1 => r_x.unwrap(),
+            j if j < WORD_SIZE => F::one(),
+            _ => checkpoints[Prefixes::Msb].unwrap(),
+        }
+    }
+
+    fn update_prefix_checkpoint(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: F,
+        r_y: F,
+        j: usize,
+    ) -> PrefixCheckpoint<F> {
+        match j {
+            j if j == WORD_SIZE => Some(r_y).into(),
+            j if j == WORD_SIZE + 1 => Some(r_x).into(),
+            j if j < WORD_SIZE => Some(F::one()).into(),
+            _ => checkpoints[Prefixes::Msb].into(),
+        }
+    }
+}

--- a/jolt-core/src/jolt/lookup_table/relu.rs
+++ b/jolt-core/src/jolt/lookup_table/relu.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+
+use super::prefixes::{PrefixEval, Prefixes};
+use super::suffixes::{SuffixEval, Suffixes};
+use super::JoltLookupTable;
+use super::PrefixSuffixDecomposition;
+use crate::field::JoltField;
+
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReLUTable<const WORD_SIZE: usize>;
+
+impl<const WORD_SIZE: usize> JoltLookupTable for ReLUTable<WORD_SIZE> {
+    fn materialize_entry(&self, index: u64) -> u64 {
+        let sign_bit = 1 << (WORD_SIZE - 1);
+        if index & sign_bit == 0 {
+            index % (1 << WORD_SIZE)
+        } else {
+            0
+        }
+    }
+
+    fn evaluate_mle<F: JoltField>(&self, r: &[F]) -> F {
+        debug_assert_eq!(r.len(), 2 * WORD_SIZE);
+        let mut result = F::zero();
+        for i in 0..WORD_SIZE - 1 {
+            result += F::from_u64(1 << i) * r[r.len() - 1 - i];
+        }
+        result *= F::one() - r[WORD_SIZE];
+        result
+    }
+}
+
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for ReLUTable<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
+        vec![Suffixes::One, Suffixes::LowerWordNoMsb, Suffixes::RightMSB]
+    }
+
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, lower_word, rmsb] = suffixes.try_into().unwrap();
+        (one - prefixes[Prefixes::Msb] * one * rmsb)
+            * (prefixes[Prefixes::LowerWordNoMsb] * one + lower_word)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_bn254::Fr;
+
+    use super::ReLUTable;
+    use crate::jolt::lookup_table::test::{
+        lookup_table_mle_full_hypercube_test, lookup_table_mle_random_test, prefix_suffix_test,
+    };
+
+    #[test]
+    fn prefix_suffix() {
+        prefix_suffix_test::<Fr, ReLUTable<32>>();
+    }
+
+    #[test]
+    fn mle_full_hypercube() {
+        lookup_table_mle_full_hypercube_test::<Fr, ReLUTable<8>>();
+    }
+
+    #[test]
+    fn mle_random() {
+        lookup_table_mle_random_test::<Fr, ReLUTable<32>>();
+    }
+}

--- a/jolt-core/src/jolt/lookup_table/suffixes/lower_word_no_msb.rs
+++ b/jolt-core/src/jolt/lookup_table/suffixes/lower_word_no_msb.rs
@@ -1,0 +1,13 @@
+use crate::subprotocols::sparse_dense_shout::LookupBits;
+
+use super::SparseDenseSuffix;
+
+/// Returns the lower WORD_SIZE - 1 bits. Used to range-check values to be in
+/// the range [0, 2^WORD_SIZE).
+pub enum LowerWordNoMsbSuffix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize> SparseDenseSuffix for LowerWordNoMsbSuffix<WORD_SIZE> {
+    fn suffix_mle(b: LookupBits) -> u32 {
+        (u64::from(b) % (1 << (WORD_SIZE - 1))) as u32
+    }
+}

--- a/jolt-core/src/jolt/lookup_table/suffixes/mod.rs
+++ b/jolt-core/src/jolt/lookup_table/suffixes/mod.rs
@@ -1,4 +1,6 @@
 use crate::jolt::lookup_table::suffixes::left_shift::LeftShiftSuffix;
+use crate::jolt::lookup_table::suffixes::lower_word_no_msb::LowerWordNoMsbSuffix;
+use crate::jolt::lookup_table::suffixes::right_msb::RightMSB;
 use crate::{field::JoltField, subprotocols::sparse_dense_shout::LookupBits};
 use div_by_zero::DivByZeroSuffix;
 use eq::EqSuffix;
@@ -29,12 +31,14 @@ pub mod gt;
 pub mod left_is_zero;
 pub mod left_shift;
 pub mod lower_word;
+pub mod lower_word_no_msb;
 pub mod lsb;
 pub mod lt;
 pub mod one;
 pub mod or;
 pub mod pow2;
 pub mod right_is_zero;
+pub mod right_msb;
 pub mod right_shift;
 pub mod right_shift_helper;
 pub mod right_shift_padding;
@@ -71,6 +75,8 @@ pub enum Suffixes {
     RightShiftHelper,
     SignExtension,
     LeftShift,
+    RightMSB,
+    LowerWordNoMsb,
 }
 
 pub type SuffixEval<F: JoltField> = F;
@@ -99,6 +105,8 @@ impl Suffixes {
             Suffixes::RightShiftHelper => RightShiftHelperSuffix::suffix_mle(b),
             Suffixes::SignExtension => SignExtensionSuffix::<WORD_SIZE>::suffix_mle(b),
             Suffixes::LeftShift => LeftShiftSuffix::suffix_mle(b),
+            Suffixes::RightMSB => RightMSB::<WORD_SIZE>::suffix_mle(b),
+            Suffixes::LowerWordNoMsb => LowerWordNoMsbSuffix::<WORD_SIZE>::suffix_mle(b),
         }
     }
 }

--- a/jolt-core/src/jolt/lookup_table/suffixes/right_msb.rs
+++ b/jolt-core/src/jolt/lookup_table/suffixes/right_msb.rs
@@ -1,0 +1,15 @@
+use crate::subprotocols::sparse_dense_shout::LookupBits;
+
+use super::SparseDenseSuffix;
+
+pub enum RightMSB<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize> SparseDenseSuffix for RightMSB<WORD_SIZE> {
+    fn suffix_mle(b: LookupBits) -> u32 {
+        if b.len() < WORD_SIZE {
+            return 1;
+        }
+
+        (((u64::from(b) % (1 << WORD_SIZE)) >> (WORD_SIZE - 1)) & 1) as u32
+    }
+}


### PR DESCRIPTION
Lookup table logic goes in this codebase. This is needed for ReLU integration in jolt-atlas

tests: 

https://github.com/ICME-Lab/zkml-jolt/blob/71505608142eb514cbd50f3259d64dea6c79b270/jolt-core/src/jolt/lookup_table/relu.rs#L46-L69

```bash
cargo test --package jolt-core --lib -- jolt::lookup_table::relu::test --show-output
```