### PR TITLE
feat: relu lookup-table logic

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,3 +46,20 @@ jobs:
       - name: Build Wasm
         working-directory: ./jolt-core
         run: cargo build --release --target wasm32-unknown-unknown
+  
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Cache Jolt RISC-V Rust toolchain
+        uses: actions/cache@v4
+        with:
+          key: jolt-rust-toolchain-${{hashFiles('guest-toolchain-tag')}}
+          path: ~/.jolt
+      - name: Install Jolt RISC-V Rust toolchain
+        run: cargo run install-toolchain
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: Run jolt-core tests
+        run: cargo nextest run --release -p jolt-core

--- a/jolt-core/src/jolt/lookup_table/mod.rs
+++ b/jolt-core/src/jolt/lookup_table/mod.rs
@@ -27,7 +27,7 @@ use virtual_sra::VirtualSRATable;
 use virtual_srl::VirtualSRLTable;
 use xor::XorTable;
 
-use crate::field::JoltField;
+use crate::{field::JoltField, jolt::lookup_table::relu::ReLUTable};
 use derive_more::From;
 use std::fmt::Debug;
 
@@ -66,6 +66,7 @@ pub mod not_equal;
 pub mod or;
 pub mod pow2;
 pub mod range_check;
+pub mod relu;
 pub mod shift_right_bitmask;
 pub mod signed_greater_than_equal;
 pub mod signed_less_than;
@@ -110,6 +111,7 @@ pub enum LookupTables<const WORD_SIZE: usize> {
     VirtualSRL(VirtualSRLTable<WORD_SIZE>),
     VirtualSRA(VirtualSRATable<WORD_SIZE>),
     VirtualROTRI(VirtualRotrTable<WORD_SIZE>),
+    ReLU(ReLUTable<WORD_SIZE>),
 }
 
 impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
@@ -144,6 +146,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.materialize(),
             LookupTables::VirtualSRA(table) => table.materialize(),
             LookupTables::VirtualROTRI(table) => table.materialize(),
+            LookupTables::ReLU(table) => table.materialize(),
         }
     }
 
@@ -171,6 +174,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.materialize_entry(index),
             LookupTables::VirtualSRA(table) => table.materialize_entry(index),
             LookupTables::VirtualROTRI(table) => table.materialize_entry(index),
+            LookupTables::ReLU(table) => table.materialize_entry(index),
         }
     }
 
@@ -198,6 +202,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.evaluate_mle(r),
             LookupTables::VirtualSRA(table) => table.evaluate_mle(r),
             LookupTables::VirtualROTRI(table) => table.evaluate_mle(r),
+            LookupTables::ReLU(table) => table.evaluate_mle(r),
         }
     }
 
@@ -225,6 +230,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.suffixes(),
             LookupTables::VirtualSRA(table) => table.suffixes(),
             LookupTables::VirtualROTRI(table) => table.suffixes(),
+            LookupTables::ReLU(table) => table.suffixes(),
         }
     }
 
@@ -256,6 +262,7 @@ impl<const WORD_SIZE: usize> LookupTables<WORD_SIZE> {
             LookupTables::VirtualSRL(table) => table.combine(prefixes, suffixes),
             LookupTables::VirtualSRA(table) => table.combine(prefixes, suffixes),
             LookupTables::VirtualROTRI(table) => table.combine(prefixes, suffixes),
+            LookupTables::ReLU(table) => table.combine(prefixes, suffixes),
         }
     }
 }

--- a/jolt-core/src/jolt/lookup_table/prefixes/lower_word_no_msb.rs
+++ b/jolt-core/src/jolt/lookup_table/prefixes/lower_word_no_msb.rs
@@ -1,0 +1,90 @@
+use crate::{
+    field::JoltField,
+    subprotocols::sparse_dense_shout::{current_suffix_len, LookupBits},
+};
+
+use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+
+pub enum LowerWordNoMsbPrefix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F>
+    for LowerWordNoMsbPrefix<WORD_SIZE>
+{
+    fn prefix_mle(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<F>,
+        c: u32,
+        mut b: LookupBits,
+        j: usize,
+    ) -> F {
+        // Ignore high-order variables
+        if j < WORD_SIZE {
+            return F::zero();
+        }
+
+        let two = 2 * WORD_SIZE;
+        let c_f = F::from_u8(c as u8);
+        let mut result = checkpoints[Prefixes::LowerWordNoMsb].unwrap_or(F::zero());
+        let mut add = |shift: usize, val: F| {
+            result += F::from_u64(1u64 << shift) * val;
+        };
+        match (r_x, j) {
+            // MSB is in c
+            (None, jj) if jj == WORD_SIZE => {
+                let y_msb = b.pop_msb();
+                let y_shift = two - j - 2;
+                add(y_shift, F::from_u8(y_msb));
+            }
+
+            // MSB is in r_x
+            (Some(_), jj) if jj == WORD_SIZE + 1 => {
+                let y_shift = two - j - 1;
+                add(y_shift, c_f);
+            }
+
+            // General cases
+            (None, _) => {
+                let y_msb = b.pop_msb();
+                let x_shift = two - j - 1;
+                let y_shift = x_shift - 1;
+                add(x_shift, c_f);
+                add(y_shift, F::from_u8(y_msb));
+            }
+            (Some(rx), _) => {
+                let x_shift = two - j;
+                let y_shift = x_shift - 1;
+                add(x_shift, rx);
+                add(y_shift, c_f);
+            }
+        }
+        let suffix_len = current_suffix_len(two, j);
+        result += F::from_u64(u64::from(b) << suffix_len);
+        result
+    }
+
+    fn update_prefix_checkpoint(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: F,
+        r_y: F,
+        j: usize,
+    ) -> PrefixCheckpoint<F> {
+        let two = 2 * WORD_SIZE;
+        match j {
+            j if j < WORD_SIZE => None.into(),
+            j if j == WORD_SIZE + 1 => {
+                let y_shift = two - j - 1;
+                let updated = checkpoints[Prefixes::LowerWordNoMsb].unwrap_or(F::zero())
+                    + F::from_u64(1 << y_shift) * r_y;
+                Some(updated).into()
+            }
+            _ => {
+                let x_shift = two - j;
+                let y_shift = x_shift - 1;
+                let updated = checkpoints[Prefixes::LowerWordNoMsb].unwrap_or(F::zero())
+                    + F::from_u64(1 << x_shift) * r_x
+                    + F::from_u64(1 << y_shift) * r_y;
+                Some(updated).into()
+            }
+        }
+    }
+}

--- a/jolt-core/src/jolt/lookup_table/prefixes/mod.rs
+++ b/jolt-core/src/jolt/lookup_table/prefixes/mod.rs
@@ -1,5 +1,8 @@
 use crate::jolt::lookup_table::prefixes::left_shift::LeftShiftPrefix;
 use crate::jolt::lookup_table::prefixes::left_shift_helper::LeftShiftHelperPrefix;
+use crate::jolt::lookup_table::prefixes::lower_word_no_msb::LowerWordNoMsbPrefix;
+use crate::jolt::lookup_table::prefixes::not_unary_msb::NotUnaryMsbPrefix;
+use crate::jolt::lookup_table::prefixes::relu::ReluPrefix;
 use crate::{field::JoltField, subprotocols::sparse_dense_shout::LookupBits};
 use lsb::LsbPrefix;
 use negative_divisor_equals_remainder::NegativeDivisorEqualsRemainderPrefix;
@@ -12,6 +15,7 @@ use pow2::Pow2Prefix;
 use rayon::prelude::*;
 use right_shift::RightShiftPrefix;
 use sign_extension::SignExtensionPrefix;
+use std::ops::Deref;
 use std::{fmt::Display, ops::Index};
 use strum::EnumCount;
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
@@ -38,15 +42,18 @@ pub mod left_msb;
 pub mod left_shift;
 pub mod left_shift_helper;
 pub mod lower_word;
+pub mod lower_word_no_msb;
 pub mod lsb;
 pub mod lt;
 pub mod negative_divisor_equals_remainder;
 pub mod negative_divisor_greater_than_remainder;
 pub mod negative_divisor_zero_remainder;
+pub mod not_unary_msb;
 pub mod or;
 pub mod positive_remainder_equals_divisor;
 pub mod positive_remainder_less_than_divisor;
 pub mod pow2;
+pub mod relu;
 pub mod right_is_zero;
 pub mod right_msb;
 pub mod right_shift;
@@ -118,6 +125,9 @@ pub enum Prefixes {
     SignExtension,
     LeftShift,
     LeftShiftHelper,
+    LowerWordNoMsb,
+    NotUnaryMsb,
+    Relu,
 }
 
 #[derive(Clone, Copy)]
@@ -133,6 +143,13 @@ impl<F: Display> Display for PrefixEval<F> {
 impl<F> From<F> for PrefixEval<F> {
     fn from(value: F) -> Self {
         Self(value)
+    }
+}
+
+impl<F> Deref for PrefixEval<F> {
+    type Target = F;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -178,6 +195,9 @@ impl Prefixes {
             Prefixes::LowerWord => {
                 LowerWordPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j)
             }
+            Prefixes::LowerWordNoMsb => {
+                LowerWordNoMsbPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j)
+            }
             Prefixes::UpperWord => {
                 UpperWordPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j)
             }
@@ -211,6 +231,9 @@ impl Prefixes {
                 NegativeDivisorGreaterThanRemainderPrefix::prefix_mle(checkpoints, r_x, c, b, j)
             }
             Prefixes::Lsb => LsbPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
+            Prefixes::NotUnaryMsb => {
+                NotUnaryMsbPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j)
+            }
             Prefixes::Pow2 => Pow2Prefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
             Prefixes::RightShift => RightShiftPrefix::prefix_mle(checkpoints, r_x, c, b, j),
             Prefixes::SignExtension => {
@@ -222,6 +245,7 @@ impl Prefixes {
             Prefixes::LeftShiftHelper => {
                 LeftShiftHelperPrefix::prefix_mle(checkpoints, r_x, c, b, j)
             }
+            Prefixes::Relu => ReluPrefix::<WORD_SIZE>::prefix_mle(checkpoints, r_x, c, b, j),
         };
         PrefixEval(eval)
     }
@@ -269,6 +293,14 @@ impl Prefixes {
         match self {
             Prefixes::LowerWord => {
                 LowerWordPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
+            }
+            Prefixes::LowerWordNoMsb => {
+                LowerWordNoMsbPrefix::<WORD_SIZE>::update_prefix_checkpoint(
+                    checkpoints,
+                    r_x,
+                    r_y,
+                    j,
+                )
             }
             Prefixes::UpperWord => {
                 UpperWordPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
@@ -344,6 +376,9 @@ impl Prefixes {
             Prefixes::Lsb => {
                 LsbPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
             }
+            Prefixes::NotUnaryMsb => {
+                NotUnaryMsbPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
+            }
             Prefixes::Pow2 => {
                 Pow2Prefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
             }
@@ -358,6 +393,9 @@ impl Prefixes {
             }
             Prefixes::LeftShiftHelper => {
                 LeftShiftHelperPrefix::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
+            }
+            Prefixes::Relu => {
+                ReluPrefix::<WORD_SIZE>::update_prefix_checkpoint(checkpoints, r_x, r_y, j)
             }
         }
     }

--- a/jolt-core/src/jolt/lookup_table/prefixes/not_unary_msb.rs
+++ b/jolt-core/src/jolt/lookup_table/prefixes/not_unary_msb.rs
@@ -1,0 +1,39 @@
+use crate::{
+    field::JoltField, jolt::lookup_table::prefixes::Prefixes,
+    subprotocols::sparse_dense_shout::LookupBits,
+};
+
+use super::{PrefixCheckpoint, SparseDensePrefix};
+
+pub enum NotUnaryMsbPrefix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for NotUnaryMsbPrefix<WORD_SIZE> {
+    fn prefix_mle(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<F>,
+        c: u32,
+        _b: LookupBits,
+        j: usize,
+    ) -> F {
+        match j {
+            // sign bit is c
+            j if j == WORD_SIZE => F::one() - F::from_u32(c),
+            // sign bit is r_x
+            j if j == WORD_SIZE + 1 => F::one() - r_x.unwrap(),
+            // sign bit has been processed, use checkpoint
+            _ => checkpoints[Prefixes::NotUnaryMsb].unwrap_or(F::one()),
+        }
+    }
+
+    fn update_prefix_checkpoint(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: F,
+        _r_y: F,
+        j: usize,
+    ) -> PrefixCheckpoint<F> {
+        match j {
+            j if j == WORD_SIZE + 1 => Some(F::one() - r_x).into(),
+            _ => checkpoints[Prefixes::NotUnaryMsb].into(),
+        }
+    }
+}

--- a/jolt-core/src/jolt/lookup_table/prefixes/relu.rs
+++ b/jolt-core/src/jolt/lookup_table/prefixes/relu.rs
@@ -1,0 +1,53 @@
+use crate::{field::JoltField, subprotocols::sparse_dense_shout::LookupBits};
+
+use super::{PrefixCheckpoint, Prefixes, SparseDensePrefix};
+
+pub enum ReluPrefix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize, F: JoltField> SparseDensePrefix<F> for ReluPrefix<WORD_SIZE> {
+    fn prefix_mle(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: Option<F>,
+        c: u32,
+        b: LookupBits,
+        j: usize,
+    ) -> F {
+        // Ignore high-order variables
+        if j < WORD_SIZE {
+            return F::zero();
+        }
+        let nsign_bit =
+            *Prefixes::NotUnaryMsb.prefix_mle::<WORD_SIZE, F>(checkpoints, r_x, c, b, j);
+        let word = *Prefixes::LowerWordNoMsb.prefix_mle::<WORD_SIZE, F>(checkpoints, r_x, c, b, j);
+        nsign_bit * word
+    }
+
+    fn update_prefix_checkpoint(
+        checkpoints: &[PrefixCheckpoint<F>],
+        r_x: F,
+        r_y: F,
+        j: usize,
+    ) -> PrefixCheckpoint<F> {
+        let two = 2 * WORD_SIZE;
+        match j {
+            // suffix handles relu
+            j if j < WORD_SIZE => None.into(),
+            j if j == WORD_SIZE + 1 => {
+                // Sign bit is in r_x
+                let sign_bit = r_x;
+                let y_shift = two - j - 1;
+                let updated = checkpoints[Prefixes::Relu].unwrap_or(F::zero())
+                    + F::from_u64(1 << y_shift) * r_y * (F::one() - sign_bit);
+                Some(updated).into()
+            }
+            _ => {
+                let x_shift = two - j;
+                let y_shift = x_shift - 1;
+                let updated = checkpoints[Prefixes::Relu].unwrap_or(F::zero())
+                    + F::from_u64(1 << x_shift) * r_x * checkpoints[Prefixes::NotUnaryMsb].unwrap()
+                    + F::from_u64(1 << y_shift) * r_y * checkpoints[Prefixes::NotUnaryMsb].unwrap();
+                Some(updated).into()
+            }
+        }
+    }
+}

--- a/jolt-core/src/jolt/lookup_table/relu.rs
+++ b/jolt-core/src/jolt/lookup_table/relu.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+
+use super::prefixes::{PrefixEval, Prefixes};
+use super::suffixes::{SuffixEval, Suffixes};
+use super::JoltLookupTable;
+use super::PrefixSuffixDecomposition;
+use crate::field::JoltField;
+
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReLUTable<const WORD_SIZE: usize>;
+
+impl<const WORD_SIZE: usize> JoltLookupTable for ReLUTable<WORD_SIZE> {
+    fn materialize_entry(&self, index: u64) -> u64 {
+        let sign_bit = 1 << (WORD_SIZE - 1);
+        if index & sign_bit == 0 {
+            index % (1 << WORD_SIZE)
+        } else {
+            0
+        }
+    }
+
+    fn evaluate_mle<F: JoltField>(&self, r: &[F]) -> F {
+        debug_assert_eq!(r.len(), 2 * WORD_SIZE);
+        let mut result = F::zero();
+        for i in 0..WORD_SIZE - 1 {
+            result += F::from_u64(1 << i) * r[r.len() - 1 - i];
+        }
+        result *= F::one() - r[WORD_SIZE];
+        result
+    }
+}
+
+impl<const WORD_SIZE: usize> PrefixSuffixDecomposition<WORD_SIZE> for ReLUTable<WORD_SIZE> {
+    fn suffixes(&self) -> Vec<Suffixes> {
+        vec![Suffixes::One, Suffixes::Relu]
+    }
+
+    fn combine<F: JoltField>(&self, prefixes: &[PrefixEval<F>], suffixes: &[SuffixEval<F>]) -> F {
+        debug_assert_eq!(self.suffixes().len(), suffixes.len());
+        let [one, relu] = suffixes.try_into().unwrap();
+        prefixes[Prefixes::Relu] * one + prefixes[Prefixes::NotUnaryMsb] * relu
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_bn254::Fr;
+
+    use super::ReLUTable;
+    use crate::jolt::lookup_table::test::{
+        lookup_table_mle_full_hypercube_test, lookup_table_mle_random_test, prefix_suffix_test,
+    };
+
+    #[test]
+    fn prefix_suffix() {
+        prefix_suffix_test::<Fr, ReLUTable<32>>();
+    }
+
+    #[test]
+    fn mle_full_hypercube() {
+        lookup_table_mle_full_hypercube_test::<Fr, ReLUTable<8>>();
+    }
+
+    #[test]
+    fn mle_random() {
+        lookup_table_mle_random_test::<Fr, ReLUTable<32>>();
+    }
+}

--- a/jolt-core/src/jolt/lookup_table/suffixes/mod.rs
+++ b/jolt-core/src/jolt/lookup_table/suffixes/mod.rs
@@ -1,4 +1,5 @@
 use crate::jolt::lookup_table::suffixes::left_shift::LeftShiftSuffix;
+use crate::jolt::lookup_table::suffixes::relu::ReluSuffix;
 use crate::{field::JoltField, subprotocols::sparse_dense_shout::LookupBits};
 use div_by_zero::DivByZeroSuffix;
 use eq::EqSuffix;
@@ -34,6 +35,7 @@ pub mod lt;
 pub mod one;
 pub mod or;
 pub mod pow2;
+pub mod relu;
 pub mod right_is_zero;
 pub mod right_shift;
 pub mod right_shift_helper;
@@ -71,6 +73,7 @@ pub enum Suffixes {
     RightShiftHelper,
     SignExtension,
     LeftShift,
+    Relu,
 }
 
 pub type SuffixEval<F: JoltField> = F;
@@ -99,6 +102,7 @@ impl Suffixes {
             Suffixes::RightShiftHelper => RightShiftHelperSuffix::suffix_mle(b),
             Suffixes::SignExtension => SignExtensionSuffix::<WORD_SIZE>::suffix_mle(b),
             Suffixes::LeftShift => LeftShiftSuffix::suffix_mle(b),
+            Suffixes::Relu => ReluSuffix::<WORD_SIZE>::suffix_mle(b),
         }
     }
 }

--- a/jolt-core/src/jolt/lookup_table/suffixes/relu.rs
+++ b/jolt-core/src/jolt/lookup_table/suffixes/relu.rs
@@ -1,0 +1,24 @@
+use crate::subprotocols::sparse_dense_shout::LookupBits;
+
+use super::SparseDenseSuffix;
+
+/// Returns the lower WORD_SIZE - 1 bits. Used to range-check values to be in
+/// the range [0, 2^WORD_SIZE).
+pub enum ReluSuffix<const WORD_SIZE: usize> {}
+
+impl<const WORD_SIZE: usize> SparseDenseSuffix for ReluSuffix<WORD_SIZE> {
+    fn suffix_mle(b: LookupBits) -> u32 {
+        let sign_bit = if b.len() < WORD_SIZE {
+            // Suffix is too small, return 0 (prefix will handle)
+            0
+        } else {
+            // Extract bit at position (half_word_size), which is the sign bit
+            let bits = u64::from(b);
+            let sign_bit_position = WORD_SIZE - 1;
+            let sign_bit = (bits >> sign_bit_position) & 1;
+            sign_bit as u32
+        };
+
+        (1 - sign_bit) * (u64::from(b) % (1 << (WORD_SIZE - 1))) as u32
+    }
+}


### PR DESCRIPTION
Lookup table logic goes in this codebase. This is needed for ReLU integration in jolt-atlas

tests: 
https://github.com/ICME-Lab/zkml-jolt/blob/d919538f737fcd3dbc0390570b839ecb2c11a73a/jolt-core/src/jolt/lookup_table/relu.rs#L46-L68

```bash
cargo test --package jolt-core --lib -- jolt::lookup_table::relu::test --show-output
```